### PR TITLE
actually use the OGC standard's time property name

### DIFF
--- a/search-catalog.ipynb
+++ b/search-catalog.ipynb
@@ -80,7 +80,7 @@
    "outputs": [],
    "source": [
     "geometry = shapely.box(-25, 43, 2, 60)\n",
-    "timespan = [\"2019-11-01\", \"2019-11-15\"]\n",
+    "timespan = [\"2023-04-15T00:00:00\", \"2023-05-02T00:00:00\"]\n",
     "\n",
     "unfiltered = client.search(\n",
     "    collections=[\"TS\"],\n",

--- a/stac_insitu/filter.py
+++ b/stac_insitu/filter.py
@@ -21,6 +21,10 @@ def extract_trajectory(item):
 
 def filter_trajectories(items, geometry, timespan):
     def predicate(item):
+        if "datetimes" not in item.properties:
+            # not a trajectory, assume this item is stationary
+            return False
+
         traj = extract_trajectory(item)
 
         segment = traj.get_segment_between(*pd.to_datetime(timespan))

--- a/stac_insitu/visualization.py
+++ b/stac_insitu/visualization.py
@@ -25,7 +25,7 @@ def transform_to_geojson(item, style_function):
 
     marker = folium.CircleMarker()
 
-    yield folium.GeoJson(
+    return folium.GeoJson(
         item.geometry,
         style_function=curry(style_function, category=category),
         marker=marker,

--- a/stac_insitu/visualization.py
+++ b/stac_insitu/visualization.py
@@ -38,7 +38,7 @@ def transform_to_timestamped_geojson(items, style_function):
             "type": "Feature",
             "geometry": item.geometry,
             "properties": {
-                "times": item.properties["time"],
+                "times": item.properties["datetimes"],
                 "style": style_function(None, extract_category(item.collection_id)),
             },
         }
@@ -53,7 +53,7 @@ def transform_to_timestamped_geojson(items, style_function):
 
 def visualize_items(items, style_function):
     def categorize(item):
-        if "time" in item.properties and item.geometry["type"] == "LineString":
+        if "datetimes" in item.properties and item.geometry["type"] == "LineString":
             return "trajectory"
         else:
             return "geojson"

--- a/stac_insitu/visualization.py
+++ b/stac_insitu/visualization.py
@@ -10,7 +10,9 @@ from tlz.itertoolz import groupby
 def itemwise(func):
     @functools.wraps(func)
     def wrapper(items, **kwargs):
-        yield from map(curry(func, **kwargs))
+        yield from map(curry(func, **kwargs), items)
+
+    return wrapper
 
 
 def extract_category(id):


### PR DESCRIPTION
follow-up to #2: the selection and visualization code made use of the old `"time"` property, and when switching to the OGC standard name I forgot to update that code.